### PR TITLE
Prevent sed removing last letter in candidate name

### DIFF
--- a/zsh-sdkman.plugin.zsh
+++ b/zsh-sdkman.plugin.zsh
@@ -83,13 +83,13 @@ __generate_all_candidate_folders_and_files() {
 ########################################################
 
 _sdkman_get_candidate_and_versions_lists_into_files() {
-  (sdk list | grep --color=never  "$ sdk install" | sed 's/\$ sdk install //g' | sed -e 's/[\t ]//g;/^$/d' > $ZSH_SDKMAN_CANDIDATE_LIST_FILE \
+  (sdk list | grep --color=never  "$ sdk install" | sed 's/\$ sdk install //g' | sed -e 's/[[:blank:]]//g;/^$/d' > $ZSH_SDKMAN_CANDIDATE_LIST_FILE \
   && __generate_all_candidate_folders_and_files &
   )
 }
 
 _sdkman_get_current_installed_list_into_file() {
-  (sdk current | sed "s/Using://g" | sed "s/\:.*//g"  | sed -e "s/[\t ]//g;/^$/d" | egrep --color=never -i -v ".*(sdkupdate|WARNING).*" > $ZSH_SDKMAN_INSTALLED_LIST_FILE &)
+  (sdk current | sed "s/Using://g" | sed "s/\:.*//g"  | sed -e "s/[[:blank:]]//g;/^$/d" | egrep --color=never -i -v ".*(sdkupdate|WARNING).*" > $ZSH_SDKMAN_INSTALLED_LIST_FILE &)
 }
 
 # Gets a candidate available versions (All of them, including already installed, not installed ...)


### PR DESCRIPTION
Hi,

please see screenshot

![image](https://user-images.githubusercontent.com/25544967/94353583-04668a00-0073-11eb-8f94-17571d10cd21.png)


Machine
Darwin macbook-pro.home 19.6.0 Darwin Kernel Version 19.6.0: Thu Jun 18 20:49:00 PDT 2020; root:xnu-6153.141.1~1/RELEASE_X86_64 x86_64
grep (BSD grep) 2.5.1-FreeBSD
sed
```console
@(#)PROGRAM:sed  PROJECT:text_cmds-101.40.1
$FreeBSD: src/usr.bin/sed/compile.c,v 1.28 2005/08/04 10:05:11 dds Exp $
$FreeBSD: src/usr.bin/sed/main.c,v 1.36 2005/05/10 13:40:50 glebius Exp $
$FreeBSD: src/usr.bin/sed/misc.c,v 1.10 2004/08/09 15:29:41 dds Exp $
$FreeBSD: src/usr.bin/sed/process.c,v 1.39 2005/04/09 14:31:41 stefanf Exp $
```