### PR TITLE
Support SDKMAN_DIR variable and XDG base directory

### DIFF
--- a/zsh-sdkman.plugin.zsh
+++ b/zsh-sdkman.plugin.zsh
@@ -28,18 +28,10 @@ alias sdkf='sdk flush'
 
 # WARNING: We are setting this as a local variable because we don't have it yet at the time of initialization
 # A better approach would be welcome
-if [ -z "${SDKMAN_DIR}" ]; then
-  SDKMAN_DIR_LOCAL=~/.sdkman
-else
-  SDKMAN_DIR_LOCAL="$SDKMAN_DIR"
-fi
+SDKMAN_DIR_LOCAL=${SDKMAN_DIR:-$HOME/.sdkman}
 
 # Custom variables for later in this script and in the completion script
-if [ -z "${ZSH_SDKMAN_DIR_LOCAL}" ]; then
-  export ZSH_SDKMAN_DIR_LOCAL=~/.zsh-sdkman
-else
-  export ZSH_SDKMAN_DIR_LOCAL="$ZSH_SDKMAN_DIR_LOCAL"
-fi
+ZSH_SDKMAN_DIR_LOCAL=${ZSH_SDKMAN_DIR:-$HOME/.zsh-sdkman}
 
 export ZSH_SDKMAN_CANDIDATES_HOME=$ZSH_SDKMAN_DIR_LOCAL/candidates
 

--- a/zsh-sdkman.plugin.zsh
+++ b/zsh-sdkman.plugin.zsh
@@ -28,10 +28,18 @@ alias sdkf='sdk flush'
 
 # WARNING: We are setting this as a local variable because we don't have it yet at the time of initialization
 # A better approach would be welcome
-SDKMAN_DIR_LOCAL=~/.sdkman
+if [ -z "${SDKMAN_DIR}" ]; then
+  SDKMAN_DIR_LOCAL=~/.sdkman
+else
+  SDKMAN_DIR_LOCAL="$SDKMAN_DIR"
+fi
 
 # Custom variables for later in this script and in the completion script
-export ZSH_SDKMAN_DIR_LOCAL=~/.zsh-sdkman
+if [ -z "${ZSH_SDKMAN_DIR_LOCAL}" ]; then
+  export ZSH_SDKMAN_DIR_LOCAL=~/.zsh-sdkman
+else
+  export ZSH_SDKMAN_DIR_LOCAL="$ZSH_SDKMAN_DIR_LOCAL"
+fi
 
 export ZSH_SDKMAN_CANDIDATES_HOME=$ZSH_SDKMAN_DIR_LOCAL/candidates
 


### PR DESCRIPTION
When using SDKMAN_DIR to comply with the xdg user directory
specification, the value of the SDKMAN_DIR variable is supported.

Implement a custom zsh-sdkman directory by specifying the value of
ZSH_SDKMAN_DIR_LOCAL.
Example: `export ZSH_SDKMAN_DIR_LOCAL="$XDG_DATA_HOME"/zsh-sdkman`