### PR TITLE
Fix wrong "sdk offline" parameters

### DIFF
--- a/_zsh-sdkman.sh
+++ b/_zsh-sdkman.sh
@@ -112,8 +112,8 @@ __describe_offline() {
   local -a offline
 
   offline=(
-    'enabled'
-    'disabled'
+    'enable'
+    'disable'
   )
 
   _describe -t offline "Offline" offline && ret=0


### PR DESCRIPTION
The parameters have an extra "d" in the completion, so the commands fail after completing.